### PR TITLE
Resolve version ranges

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.nixos.mvn2nix</groupId>
   <artifactId>mvn2nix-maven-plugin</artifactId>
-  <version>1.2.1</version>
+  <version>1.3.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>mvn2nix</name>

--- a/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
+++ b/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
@@ -523,6 +523,9 @@ public class Mvn2NixMojo extends AbstractMojo
 		}
 
 		for (Dependency subDep : res.getDependencies()) {
+			if (subDep.isOptional()) {
+				continue;
+			}
 			String scope = subDep.getScope();
 			if (scope != null && (scope.equals("provided")
 				|| scope.equals("test")

--- a/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
+++ b/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
@@ -206,6 +206,11 @@ public class Mvn2NixMojo extends AbstractMojo
 		}
 	}
 
+	private void emitProjectBody(Artifact art, Collection<Dependency> deps,
+		JsonGenerator gen) {
+		emitArtifactBody(art, deps, null, "", "", gen);
+	}
+
 	private void emitArtifactRepo(
 		ArtifactDescriptorResult res,
 		RemoteRepository repo,
@@ -617,12 +622,9 @@ public class Mvn2NixMojo extends AbstractMojo
 				gen.writeStartObject();
 
 				gen.writeStartObject("project");
-				emitArtifactBody(
+				emitProjectBody(
 				                 mavenArtifactToArtifact(project.getArtifact()),
 				                 work,
-												 null,
-												 "",
-												 "",
 				                 gen);
 				gen.writeEnd();
 

--- a/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
+++ b/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
@@ -523,9 +523,6 @@ public class Mvn2NixMojo extends AbstractMojo
 		}
 
 		for (Dependency subDep : res.getDependencies()) {
-			if (subDep.isOptional()) {
-				continue;
-			}
 			String scope = subDep.getScope();
 			if (scope != null && (scope.equals("provided")
 				|| scope.equals("test")

--- a/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
+++ b/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
@@ -429,7 +429,7 @@ public class Mvn2NixMojo extends AbstractMojo
 		}
 		String version = verRes.getHighestVersion().toString();
 		getLog().info(String.format("resolved version %s:%s", art.getArtifactId(), version));
-		art.setVersion(version);
+		art = art.setVersion(version);
 
 		ArtifactDescriptorRequest req = new ArtifactDescriptorRequest(
 			art,

--- a/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
+++ b/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
@@ -471,9 +471,9 @@ public class Mvn2NixMojo extends AbstractMojo
 			art.getExtension(),
 			version);
 		if (printed.add(artKey)) {
-			gen.writeStartObject();
 			ArtifactRepository repo = res.getRepository();
 			if (repo instanceof RemoteRepository) {
+				gen.writeStartObject();
 				emitArtifactBody(art,
 					res.getDependencies(),
 					metadataInfo,
@@ -482,7 +482,9 @@ public class Mvn2NixMojo extends AbstractMojo
 					gen);
 
 				emitArtifactRepo(res, (RemoteRepository) repo, gen);
+				gen.writeEnd();
 			} else if (repo instanceof LocalRepository) {
+				gen.writeStartObject();
 				LocalRepositoryManager localManager =
 					repoSession.getLocalRepositoryManager();
 				LocalArtifactRequest localReq =
@@ -498,6 +500,7 @@ public class Mvn2NixMojo extends AbstractMojo
 					gen);
 
 				emitArtifactRepo(res, localArtifact.getRepository(), gen);
+				gen.writeEnd();
 			} else if (repo instanceof WorkspaceRepository) {
 				// Do nothing
 			} else {
@@ -507,7 +510,6 @@ public class Mvn2NixMojo extends AbstractMojo
 						art.getArtifactId())
 				);
 			}
-			gen.writeEnd();
 		}
 
 		if (!art.getExtension().equals("pom")) {

--- a/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
+++ b/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
@@ -480,9 +480,8 @@ public class Mvn2NixMojo extends AbstractMojo
 			} else {
 				throw new MojoExecutionException(
 					String.format(
-						"Could not resolve remote repository for %s in %s",
-						art.getArtifactId(),
-						repo.getId())
+						"Could not resolve remote repository for %s",
+						art.getArtifactId())
 				);
 			}
 			gen.writeEnd();

--- a/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
+++ b/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
@@ -67,8 +67,11 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.resolution.VersionResult;
+import org.eclipse.aether.resolution.VersionRangeResult;
 import org.eclipse.aether.resolution.VersionRequest;
+import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.repository.LocalArtifactRequest;
 import org.eclipse.aether.repository.LocalArtifactResult;
@@ -415,16 +418,16 @@ public class Mvn2NixMojo extends AbstractMojo
 			}
 		}
 
-		VersionRequest verReq = new VersionRequest(art, repos, null);
-		VersionResult verRes;
+		VersionRangeRequest verReq = new VersionRangeRequest(art, repos, null);
+		VersionRangeResult verRes;
 		try {
-			verRes = repoSystem.resolveVersion(repoSession, verReq);
-		} catch (VersionResolutionException e) {
+			verRes = repoSystem.resolveVersionRange(repoSession, verReq);
+		} catch (VersionRangeResolutionException e) {
 			throw new MojoExecutionException(
 				"getting version for " + art.toString(),
 				e);
 		}
-		String version = verRes.getVersion();
+		String version = verRes.getHighestVersion().toString();
 		getLog().info(String.format("resolved version %s:%s", art.getArtifactId(), version));
 		art.setVersion(version);
 


### PR DESCRIPTION
Always takes the highest version in a range. A single version is also treated as a range.


Tried it with a 

```nix
with import <nixpkgs> { };

(buildMaven ./project-info.json).build
```

but it still complained about missing `url` fields.

Do you know of a quick way to query the huge JSON object to find missing `url`s?