### PR TITLE
Install test dependencies

### DIFF
--- a/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
+++ b/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
@@ -461,7 +461,6 @@ public class Mvn2NixMojo extends AbstractMojo
 			}
 			String scope = subDep.getScope();
 			if (scope != null && (scope.equals("provided")
-				|| scope.equals("test")
 				|| scope.equals("system"))) {
 				continue;
 			}


### PR DESCRIPTION
Dependencies with `<scope>test</scope>` must not be skipped, as they are
required as part of the `test` goal, which is a prerequisite of the
`install` goal.