### PR TITLE
Revert "Install test dependencies"

### DIFF
--- a/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
+++ b/src/main/java/org/nixos/mvn2nix/Mvn2NixMojo.java
@@ -461,6 +461,7 @@ public class Mvn2NixMojo extends AbstractMojo
 			}
 			String scope = subDep.getScope();
 			if (scope != null && (scope.equals("provided")
+				|| scope.equals("test")
 				|| scope.equals("system"))) {
 				continue;
 			}


### PR DESCRIPTION
Reverts ttuegel/mvn2nix-maven-plugin#2.

Reason: https://github.com/NixOS/mvn2nix-maven-plugin/issues/16#issuecomment-413671736.